### PR TITLE
update shippable yml file

### DIFF
--- a/shippable.yml
+++ b/shippable.yml
@@ -1,23 +1,28 @@
  language: ruby
- 
+
  rvm:
   - 2.3.1
-  
+
  env:
    global:
    - secure: NdeNVBv2zZpGOUoORIRuy0qAu6GvILMUgEtTUB2cBM+4lXUErSbSYblp0ijcMmE50F8yI5HO1FJJUnyTnHZ6KXrcbYDB7iUBldXRiGjEkSWjcd5nJLL7N/CnSnwaP9UJnRKplYJOGhjAwpIC2jl17qPT2E1nFkbrlasORkuRaUKCdlVwe4T7t3brQd+Bia+UFh096dG2y0dt0o9lQWwp+yaYc6J6dWIeCfQDzbccL8sLEv64VL0SwRR4j8NhzutAWezS285qfIj2CSLYlgI/d2nxoW8MqXBZpAroYbIBkUeaWdaKIMJ7NvArlGIJQVuluT4Pa5qpjPgmXe8wdZK8mQ==
-   
+
  build:
-  ci: 
+  ci:
    - bundle install
    - bundle exec rubocop --format emacs --out tmp/rubocop.txt || true
    - bundle exec brakeman -o tmp/brakeman.json
    - bundle exec brakeman_translate_checkstyle_format translate --file="tmp/brakeman.json" > tmp/brakeman_checkstyle.xml
    - bundle exec scss-lint --no-color --format=Stats --format=Default --out=tmp/scss-lint.txt  app/assets/stylesheets/ || true
-  
+
    - bundle exec rake minitest test
 
-# Requires TESTSPACE_TOKEN environment variable. Also note that CI_REPORTS is referenced in .testspace.txt 
-  post_ci: 
+# Requires TESTSPACE_TOKEN environment variable. Also note that CI_REPORTS is referenced in .testspace.txt
+# Both on_success and on_failure are required so the test results are published to Testspace not what happens in build.
+  on_success:
+   - curl -s https://testspace-client.s3.amazonaws.com/testspace-linux.tgz | sudo tar -zxvf- -C /usr/local/bin
+   - CI_REPORTS=$PWD/test/reports testspace @.testspace.txt $TESTSPACE_TOKEN/${SHIPPABLE_REPO_SLUG/\//:}/${BRANCH}#ship.Build.${BUILD_NUMBER}
+
+  on_failure:
    - curl -s https://testspace-client.s3.amazonaws.com/testspace-linux.tgz | sudo tar -zxvf- -C /usr/local/bin
    - CI_REPORTS=$PWD/test/reports testspace @.testspace.txt $TESTSPACE_TOKEN/${SHIPPABLE_REPO_SLUG/\//:}/${BRANCH}#ship.Build.${BUILD_NUMBER}

--- a/shippable.yml
+++ b/shippable.yml
@@ -8,6 +8,8 @@
    - secure: NdeNVBv2zZpGOUoORIRuy0qAu6GvILMUgEtTUB2cBM+4lXUErSbSYblp0ijcMmE50F8yI5HO1FJJUnyTnHZ6KXrcbYDB7iUBldXRiGjEkSWjcd5nJLL7N/CnSnwaP9UJnRKplYJOGhjAwpIC2jl17qPT2E1nFkbrlasORkuRaUKCdlVwe4T7t3brQd+Bia+UFh096dG2y0dt0o9lQWwp+yaYc6J6dWIeCfQDzbccL8sLEv64VL0SwRR4j8NhzutAWezS285qfIj2CSLYlgI/d2nxoW8MqXBZpAroYbIBkUeaWdaKIMJ7NvArlGIJQVuluT4Pa5qpjPgmXe8wdZK8mQ==
 
  build:
+  pre_ci:
+    - curl -s https://testspace-client.s3.amazonaws.com/testspace-linux.tgz | sudo tar -zxvf- -C /usr/local/bin
   ci:
    - bundle install
    - bundle exec rubocop --format emacs --out tmp/rubocop.txt || true
@@ -20,9 +22,7 @@
 # Requires TESTSPACE_TOKEN environment variable. Also note that CI_REPORTS is referenced in .testspace.txt
 # Both on_success and on_failure are required so the test results are published to Testspace not what happens in build.
   on_success:
-   - curl -s https://testspace-client.s3.amazonaws.com/testspace-linux.tgz | sudo tar -zxvf- -C /usr/local/bin
    - CI_REPORTS=$PWD/test/reports testspace @.testspace.txt $TESTSPACE_TOKEN/${SHIPPABLE_REPO_SLUG/\//:}/${BRANCH}#ship.Build.${BUILD_NUMBER}
 
   on_failure:
-   - curl -s https://testspace-client.s3.amazonaws.com/testspace-linux.tgz | sudo tar -zxvf- -C /usr/local/bin
    - CI_REPORTS=$PWD/test/reports testspace @.testspace.txt $TESTSPACE_TOKEN/${SHIPPABLE_REPO_SLUG/\//:}/${BRANCH}#ship.Build.${BUILD_NUMBER}

--- a/shippable.yml
+++ b/shippable.yml
@@ -8,8 +8,6 @@
    - secure: NdeNVBv2zZpGOUoORIRuy0qAu6GvILMUgEtTUB2cBM+4lXUErSbSYblp0ijcMmE50F8yI5HO1FJJUnyTnHZ6KXrcbYDB7iUBldXRiGjEkSWjcd5nJLL7N/CnSnwaP9UJnRKplYJOGhjAwpIC2jl17qPT2E1nFkbrlasORkuRaUKCdlVwe4T7t3brQd+Bia+UFh096dG2y0dt0o9lQWwp+yaYc6J6dWIeCfQDzbccL8sLEv64VL0SwRR4j8NhzutAWezS285qfIj2CSLYlgI/d2nxoW8MqXBZpAroYbIBkUeaWdaKIMJ7NvArlGIJQVuluT4Pa5qpjPgmXe8wdZK8mQ==
 
  build:
-  pre_ci:
-    - curl -s https://testspace-client.s3.amazonaws.com/testspace-linux.tgz | sudo tar -zxvf- -C /usr/local/bin
   ci:
    - bundle install
    - bundle exec rubocop --format emacs --out tmp/rubocop.txt || true
@@ -22,7 +20,9 @@
 # Requires TESTSPACE_TOKEN environment variable. Also note that CI_REPORTS is referenced in .testspace.txt
 # Both on_success and on_failure are required so the test results are published to Testspace not what happens in build.
   on_success:
+   - curl -s https://testspace-client.s3.amazonaws.com/testspace-linux.tgz | sudo tar -zxvf- -C /usr/local/bin
    - CI_REPORTS=$PWD/test/reports testspace @.testspace.txt $TESTSPACE_TOKEN/${SHIPPABLE_REPO_SLUG/\//:}/${BRANCH}#ship.Build.${BUILD_NUMBER}
 
   on_failure:
+   - curl -s https://testspace-client.s3.amazonaws.com/testspace-linux.tgz | sudo tar -zxvf- -C /usr/local/bin
    - CI_REPORTS=$PWD/test/reports testspace @.testspace.txt $TESTSPACE_TOKEN/${SHIPPABLE_REPO_SLUG/\//:}/${BRANCH}#ship.Build.${BUILD_NUMBER}


### PR DESCRIPTION
The changes allows shippable to publish to with or without failures to shippable. The topic_shippable_branch published as well.